### PR TITLE
Changed license to have correct package name

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-The FooBar.jl package is licensed under the MIT "Expat" License:
+The BackpropNeuralNet.jl package is licensed under the MIT "Expat" License:
 
 > Copyright (c) 2014: Christopher Brickley.
 >


### PR DESCRIPTION
The license previously talked about `FooBar.jl` - I guess this was automatically generated :D